### PR TITLE
feat: 로그인 유지 상태 관리 구현, 자잘한 css 변경/#31

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,4 +1,3 @@
-
 import myPageIcon from "./../../assets/myPageIcon.png";
 import useUserStore from "../../store/useUserStore";
 import supabase from "../../apis/supabase/supabase.config";
@@ -31,6 +30,7 @@ function Header() {
               >
                 로그아웃
               </button>
+              <img onClick={() => navigate("/mypage")} src={myPageIcon} alt="user" className="h-6 w-6" />
             </>
           ) : (
             <>

--- a/src/components/LoginComponents/LoginForm.jsx
+++ b/src/components/LoginComponents/LoginForm.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { Link, Navigate, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import supabase from "../../apis/supabase/supabase.config";
 import InputField from "./InputField";
 import useUserStore from "../../store/useUserStore";
@@ -53,6 +53,8 @@ function LoginForm() {
         throw new Error(error.message);
       }
     }
+    localStorage.setItem("user", JSON.stringify(data.user));
+
     return data;
   };
 

--- a/src/components/SignUpComponents/InputField.jsx
+++ b/src/components/SignUpComponents/InputField.jsx
@@ -7,7 +7,7 @@ function InputField({ label, type, placeholder, value, onChange, errorMessage, c
       <div className="relative">
         <input
           type={type}
-          className="w-full h-12 px-3 py-2 border rounded-[10px]"
+          className="w-full h-12 px-3 py-2 pr-28 border rounded-[10px]"
           placeholder={placeholder}
           value={value}
           onChange={onChange}

--- a/src/components/SignUpComponents/SignUpForm.jsx
+++ b/src/components/SignUpComponents/SignUpForm.jsx
@@ -164,8 +164,10 @@ function SignUpForm() {
       >
         {isLoading ? "회원가입 중..." : "회원가입 하기"}
       </button>
-      <div className="mb-5 underline flex justify-center">
-        <Link to="/login">이미 회원이신가요? 로그인 하러 가기</Link>
+      <div className="mb-5 flex justify-center">
+        <Link to="/login">
+          이미 회원이신가요? <span className="underline">로그인 하러 가기</span>
+        </Link>
       </div>
     </form>
   );

--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -3,8 +3,8 @@ import LoginForm from "../../components/LoginComponents/LoginForm";
 
 function LoginPage() {
   return (
-    <div className="flex flex-col items-center justify-center bg-white">
-      <div className="mt-40 bg-white p-8 border-[1.5px] border-blue-300 rounded-[10px] w-[600px] h-[600px]">
+    <div className="flex flex-col items-center justify-center bg-white min-h-screen">
+      <div className="bg-white p-8 border-[1.5px] border-blue-300 rounded-[10px] w-[600px] h-[600px]">
         <h2 className="mt-10 text-3xl font-bold mb-8 text-center">로그인</h2>
         <LoginForm />
       </div>

--- a/src/pages/SignUpPage/SingUpPage.jsx
+++ b/src/pages/SignUpPage/SingUpPage.jsx
@@ -3,8 +3,8 @@ import SignUpForm from "../../components/SignUpComponents/SignUpForm";
 
 function SignUpPage() {
   return (
-    <div className="flex flex-col items-center justify-center bg-white">
-      <div className="mt-32 bg-white p-8 border-[1.5px] border-blue-300 rounded-[10px] w-[600px] h-[700px]">
+    <div className="flex flex-col items-center justify-center bg-white min-h-screen">
+      <div className="bg-white p-8 border-[1.5px] border-blue-300 rounded-[10px] w-[600px] h-[700px]">
         <h2 className="mt-4 text-3xl font-bold mb-8 text-center">회원가입</h2>
         <SignUpForm />
       </div>

--- a/src/store/useUserStore.js
+++ b/src/store/useUserStore.js
@@ -1,8 +1,15 @@
-import { create } from 'zustand'
+import { create } from 'zustand';
 
 const useUserStore = create((set) => ({
-    user: null,
-    setUser: (newUser) => set(() => ({ user: newUser }))
-}))
+    user: JSON.parse(localStorage.getItem("user")) || null,
+    setUser: (newUser) => {
+        localStorage.setItem("user", JSON.stringify(newUser));
+        set(() => ({ user: newUser }));
+    },
+    logout: () => {
+        localStorage.removeItem("user");
+        set(() => ({ user: null }));
+    },
+}));
 
-export default useUserStore
+export default useUserStore;


### PR DESCRIPTION
- localstorage 활용하여 로그인 유지 상태 관리 구현하였습니다

- 로그인 하기 전에는 헤더에 마이페이지로 갈 수 있는 아이콘이 있는데 로그인 이후 헤더에 마이페이지로 가는 아이콘이 없어지는 문제 있어서 로그인 이후에도 아이콘이 보이도록 수정하였습니다.

- 로그인 / 회원가입 페이지 내 박스가 수직 중앙 정렬로 맞춰져 화면 정중앙에 위치하도록 하였습니다.

- 회원가입 페이지에서 '이미 회원이신가요?' 부분에 underline 제거하였습니다.

- '중복확인' 버튼이 input 박스 내 자리 공간을 차지하고 있는게 아니라, 아이디나 닉네임을 길게 쓰면 버튼에 가려져 보이는 문제가 있어서 버튼에 가리지 않게 수정하였습니다.